### PR TITLE
Add Dockerfile to build the janitor image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+LICENSE
+tests/
+requirements-dev.txt
+.git/
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.6-slim-stretch
+
+COPY ./ /opt/janitor/
+COPY ./docker/nginx.conf /etc/nginx/sites-enabled/janitor
+COPY ./docker/supervisor.conf /etc/supervisor/conf.d/janitor.conf
+
+RUN apt-get update \
+ && apt-get install -y nginx ca-certificates supervisor gcc libmariadbclient-dev libpq-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+ && pip --no-cache install gunicorn \
+ && pip --no-cache install -r /opt/janitor/requirements.txt \
+ && rm /etc/nginx/sites-enabled/default
+
+EXPOSE 80
+
+CMD ["sh", "-c", "/usr/bin/supervisord && /usr/sbin/nginx -g \"daemon off;\""]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    # listen on port 80 (http)
+    listen 80;
+    server_name _;
+    access_log /var/log/janitor_access.log;
+    error_log /var/log/janitor_error.log;
+    location / {
+        # forward application requests to the gunicorn server
+        proxy_pass http://localhost:8000;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /static {
+        # handle static files directly, without forwarding to the application
+        alias /opt/janitor/app/static;
+        expires 30d;
+    }
+}

--- a/docker/supervisor.conf
+++ b/docker/supervisor.conf
@@ -1,0 +1,8 @@
+[program:janitor]
+command=/usr/local/bin/gunicorn -b localhost:8000 -w 4 janitor:app --preload
+directory=/opt/janitor
+user=root
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+pytest-mock
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-pytest
 icalendar
 mysqlclient
+psycopg2
 uwsgi
 python-dotenv
-pytest-mock
-pytest-cov
 undecorated
 google-api-python-client
 google-auth-httplib2


### PR DESCRIPTION
Usage:

```bash
$ docker build . -t janitor
$ docker run --rm -p 80:80 -d janitor
```

To pass the `.env` file, can run with `docker run --rm -d --env-file /path/to/.env -p 80:80 janitor`
