### PR TITLE
Fix typo in mariadb connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ pip3 install -r requirements.txt
 ```
 PROJECT_ROOT='/opt/janitor'
 # mariadb:
-DATABASE_URL='mysql://janitor@localhost:mypass/janitor?charset=utf8'
+DATABASE_URL='mysql://janitor:mypass@localhost/janitor?charset=utf8'
 # postgres:
 DATABASE_URL='postgresql+psycopg2://janitor:mypass@127.0.0.1:5432/janitor'
 CHECK_INTERVAL=300


### PR DESCRIPTION
Fixes a typo in the example connection string for MariaDB. Currently with the incorrect format it things the password is a port and you get this error when you first try to connect and initialize the database

`ValueError: invalid literal for int() with base 10:`