### PR TITLE
fix gtt parser - service can be anywhere in line and can contain space

### DIFF
--- a/app/Providers.py
+++ b/app/Providers.py
@@ -653,8 +653,8 @@ class GTT(Provider):
         a_side = set()
 
         for line in soup.text.splitlines():
-            if line.lower().startswith('gtt service'):
-                cid = re.search(r'= (\S+)', line)
+            if 'gtt service' in line.lower():
+                cid = re.search(r'= (.+);', line)
                 if cid:
                     cids.add(cid.groups()[0])
             elif line.lower().startswith('site address'):

--- a/app/Providers.py
+++ b/app/Providers.py
@@ -654,7 +654,7 @@ class GTT(Provider):
 
         for line in soup.text.splitlines():
             if 'gtt service' in line.lower():
-                cid = re.search(r'= (.+);', line)
+                cid = re.search(r'GTT Service = (.+);', line)
                 if cid:
                     cids.add(cid.groups()[0])
             elif line.lower().startswith('site address'):


### PR DESCRIPTION
fixes #11 where 'gtt service' can be defined anywhere in the line. There can also be a space in the service such as 'IP Transit/12345'