### PR TITLE
Add Sentry monitoring

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,10 +33,7 @@ scheduler = APScheduler()
 
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 if HAS_SENTRY and SENTRY_DSN:
-    sentry_sdk.init(
-        dsn=SENTRY_DSN,
-        integrations=[FlaskIntegration()]
-    )
+    sentry_sdk.init(dsn=SENTRY_DSN, integrations=[FlaskIntegration()])
 
 
 def process_startup():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,7 @@
+import os
 import logging
 from logging.handlers import RotatingFileHandler
+
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_moment import Moment
@@ -12,6 +14,14 @@ from config import Config
 from flask_uploads import UploadSet, DOCUMENTS, configure_uploads
 import connexion
 
+try:
+    import sentry_sdk
+    from sentry_sdk.integrations.flask import FlaskIntegration
+
+    HAS_SENTRY = True
+except ImportError:
+    HAS_SENTRY = False
+
 db = SQLAlchemy()
 moment = Moment()
 migrate = Migrate()
@@ -19,6 +29,14 @@ bootstrap = Bootstrap()
 ma = Marshmallow()
 documents = UploadSet('documents', DOCUMENTS)
 scheduler = APScheduler()
+
+
+SENTRY_DSN = os.environ.get('SENTRY_DSN')
+if HAS_SENTRY and SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[FlaskIntegration()]
+    )
 
 
 def process_startup():

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ flask_bootstrap
 flask_uploads
 flask_wtf
 flask_migrate
+sentry-sdk[flask]==0.12.3


### PR DESCRIPTION
Useful to catch errors that happen in the background.

Simply create a new Sentry project, copy the generated DSN and put it in the `SENTRY_DSN` env var to start logging issues.