### PR TITLE
Field cancelled is type boolean

### DIFF
--- a/app/Providers.py
+++ b/app/Providers.py
@@ -141,7 +141,7 @@ class StandardProvider(Provider):
         if not maint:
             return False
 
-        maint.cancelled = 1
+        maint.cancelled = '1'
 
         self.add_and_commit(maint)
 
@@ -402,7 +402,7 @@ class Zayo(Provider):
         if not maint:
             return False
 
-        maint.cancelled = 1
+        maint.cancelled = '1'
 
         self.add_and_commit(maint)
 
@@ -721,7 +721,7 @@ class GTT(Provider):
         if not maint:
             return False
 
-        maint.cancelled = 1
+        maint.cancelled = '1'
 
         self.add_and_commit(maint)
 
@@ -873,7 +873,7 @@ class Telia(Provider):
         if not maint:
             return False
 
-        maint.cancelled = 1
+        maint.cancelled = '1'
 
         self.add_and_commit(maint)
 


### PR DESCRIPTION
When a maintenance is cancelled, it currently throws:

```
DatatypeMismatch: column "cancelled" is of type boolean but expression is of type integer
LINE 1: ...', '17:00:00'::time, '22:00:00'::time, 'Pacific', 0, 0, NULL...
                                                             ^
HINT:  You will need to rewrite or cast the expression.

  File "sqlalchemy/engine/base.py", line 1249, in _execute_context
    cursor, statement, parameters, context
  File "sqlalchemy/engine/default.py", line 580, in do_execute
    cursor.execute(statement, parameters)

ProgrammingError: (psycopg2.errors.DatatypeMismatch) column "cancelled" is of type boolean but expression is of type integer
LINE 1: ...', '17:00:00'::time, '22:00:00'::time, 'Pacific', 0, 0, NULL...
                                                             ^
HINT:  You will need to rewrite or cast the expression.

[SQL: INSERT INTO maintenance (provider_maintenance_id, start, "end", timezone, cancelled, rescheduled, rescheduled_id, location, reason, received_dt, started, ended) VALUES (%(provider_maintenance_id)s, %(s...
(24 additional frame(s) were not displayed)
...
  File "sqlalchemy/engine/base.py", line 1473, in _handle_dbapi_exception
    util.raise_from_cause(sqlalchemy_exception, exc_info)
  File "sqlalchemy/util/compat.py", line 398, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "sqlalchemy/util/compat.py", line 152, in reraise
    raise value.with_traceback(tb)
  File "sqlalchemy/engine/base.py", line 1249, in _execute_context
    cursor, statement, parameters, context
  File "sqlalchemy/engine/default.py", line 580, in do_execute
    cursor.execute(statement, parameters)

Job "<Job (id=run_loop name=run_loop)>" raised an exception
```