### PR TITLE
add more prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ pip3 install gunicorn
 2. create /etc/supervisor/conf.d/janitor.conf with the following contents:
 ```
 [program:janitor]
-command=/opt/janitor/venv/bin/gunicorn -b localhost:8000 -w 4 janitor:app --preload
+command=/opt/janitor/venv/bin/gunicorn -b localhost:8000 -c /opt/janitor/gunicorn_config.py -w 4 janitor:app --preload
 directory=/opt/janitor
 user=root
 autostart=true

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ If you wish to send messages to slack, you can define this. default: None
 ### SLACK_CHANNEL
 The channel to post slack messages to. default: None
 
+### PROMETHEUS_DIR
+The directory to store multiprocess prometheus metrics. default: /tmp/janitor_prometheus 
+
 
 # database schema
 

--- a/app/Providers.py
+++ b/app/Providers.py
@@ -46,7 +46,12 @@ IN_PROGRESS = Gauge('janitor_maintenances_inprogress',
               registry=registry
                     )
 
+class ParsingError(Exception):
+    '''
+    Raised when unable to parse the maintenance notification.
+    '''
 
+    pass
 
 class Provider(metaclass=ABCMeta):
     '''

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import os
 from logging.handlers import RotatingFileHandler
 
 from flask import Flask

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from logging.handlers import RotatingFileHandler
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
@@ -11,6 +12,8 @@ from flask_bootstrap import Bootstrap
 from config import Config
 from flask_uploads import UploadSet, DOCUMENTS, configure_uploads
 import connexion
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from prometheus_client import multiprocess, make_wsgi_app, CollectorRegistry
 
 db = SQLAlchemy()
 moment = Moment()
@@ -19,6 +22,7 @@ bootstrap = Bootstrap()
 ma = Marshmallow()
 documents = UploadSet('documents', DOCUMENTS)
 scheduler = APScheduler()
+registry = CollectorRegistry()
 
 
 def process_startup():
@@ -38,6 +42,28 @@ def create_app(config_class=Config):
         }
     ]
     app.config['JOBS'] = JOBS
+
+    metrics_dir = app.config['PROMETHEUS_DIR']
+
+    if not metrics_dir:
+        metrics_dir = '/tmp/janitor_prometheus'
+
+    os.environ['prometheus_multiproc_dir'] = metrics_dir
+
+    if not os.path.exists(metrics_dir):
+        try:
+            os.makedirs(metrics_dir)
+        except OSError:
+            # app.logger.error("Failed to create metrics directory!")
+            raise Exception("Failed to create metrics directory!")
+
+    files = os.listdir(metrics_dir)
+
+    for f in files:
+        if f.endswith(".db"):
+            os.remove(os.path.join(metrics_dir, f))
+
+
 
     db.init_app(app)
     moment.init_app(app)
@@ -81,6 +107,13 @@ def create_app(config_class=Config):
 
         app.logger.setLevel(log_level[app.config['LOG_LEVEL']])
         app.logger.info('janitor app started')
+
+    multiprocess.MultiProcessCollector(registry)
+
+    app.wsgi_app = DispatcherMiddleware(app.wsgi_app, {
+        '/metrics': make_wsgi_app(registry)
+    })
+
 
     return app
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -28,22 +28,8 @@ from app.main.forms import AddCircuitForm, AddCircuitContract, EditCircuitForm
 from app.jobs.main import process, failed_messages
 
 
-# @todo: expose some interesting metrics
-MAIN_REQUESTS = pc.Counter(
-    'main_page_requests_total', 'total requests for the / route.'
-)
-
-
-@bp.route('/metrics')
-def metrics():
-    return Response(
-        pc.generate_latest(), mimetype='text/plain; version=0.0.4; charset=utf-8'
-    )
-
-
 @bp.route('/', methods=['GET', 'POST'])
 def main():
-    MAIN_REQUESTS.inc()
     next_run = db.session.query(ApschedulerJobs).filter_by(id='run_loop').first()
     if next_run:
         next_run = datetime.utcfromtimestamp(next_run.next_run_time)

--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ class Config(object):
     MAIL_SERVER = os.environ.get('MAIL_SERVER')
     MAIL_CLIENT = os.environ.get('MAIL_CLIENT')
     JANITOR_URL = os.environ.get('JANITOR_URL')
+    PROMETHEUS_DIR = os.environ.get('prometheus_multiproc_dir') or os.environ.get('PROMETHEUS_DIR')
     # Uploads
     UPLOADS_DEFAULT_DEST = PROJECT_ROOT + '/app/static/circuits/'
     UPLOADED_DOCUMENTS_DEST = PROJECT_ROOT + '/app/static/circuits/'

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,0 +1,4 @@
+from prometheus_client import multiprocess
+
+def child_exit(server, worker):
+    multiprocess.mark_process_dead(worker.pid)


### PR DESCRIPTION
This exposes some relevant prometheus metrics at /metrics. Available metrics include:
  * total number of parent maintenances - that is, maintenances with a maintenance_id
  * total number of maintenances on a circuit. This is separated from parent maintenances because one parent maintenance may affect the same circuit over the course of several maintenance window under a single maintenance id
  * maintenances in progress

This requires the `gunicorn_config.py` file to be added as gunicorn config. For example:
```
gunicorn -b localhost:5000 -w 4 -c gunicorn_config.py janitor:app --preload
```
This addresses #1 