### PR TITLE
0.3.0 - new endpoints, jobs for marking maints started/ended

### DIFF
--- a/api/v1/maintenances.py
+++ b/api/v1/maintenances.py
@@ -98,12 +98,21 @@ def ending_soon(minutes=5):
         if maint.maintenance.ended:
             continue
 
+        # skip maintenances that have not yet started
+        if not maint.maintenance.started:
+            continue
+
         end = datetime.combine(
             maint.date,
             maint.maintenance.end,
             pytz.timezone(maint.maintenance.timezone),
             )
         end_utc = end.astimezone(pytz.utc)
+
+        # if end time is before start time, we assume this
+        # goes into the next day, and need to account for that
+        if maint.maintenance.start > maint.maintenance.end:
+            end_utc = end_utc + timedelta(days=1)
 
         if end_utc < (now + timedelta(minutes=minutes)):
             ending_soon.append(maint)

--- a/api/v1/maintenances.py
+++ b/api/v1/maintenances.py
@@ -1,6 +1,8 @@
-from app.models import Maintenance, MaintenanceSchema
+from app.models import Maintenance, MaintenanceSchema, MaintCircuit
 from flask import make_response, jsonify
 from app import db
+from datetime import datetime, timedelta
+import pytz
 
 
 def read_all():
@@ -15,9 +17,9 @@ def read_all():
 
     return schema.dump(maints).data
 
-
 def read_one(maintenance_id):
-    maint = Maintenance.query.filter(Maintenance.id == maintenance_id).one_or_none()
+    maint = Maintenance.query.filter(
+        Maintenance.id == maintenance_id).one_or_none()
 
     if not maint:
         text = f'maintenance not found for id {maintenance_id}'
@@ -27,3 +29,88 @@ def read_one(maintenance_id):
     data = schema.dump(maint).data
 
     return data
+
+
+def in_progress():
+    maints = Maintenance.query.filter(
+        Maintenance.started == 1).filter(Maintenance.ended == 0).all()
+
+    schema = MaintenanceSchema(many=True)
+
+    return schema.dump(maints).data
+
+
+def starting_soon(minutes=5):
+    now = datetime.now(tz=pytz.utc)
+
+    starting_soon = []
+
+    # first we get a list of upcoming MaintCircuits, which have the date only
+
+    upcoming = MaintCircuit.query.filter(
+       MaintCircuit.date >= now.date(),
+       MaintCircuit.date <= (now.date() + timedelta(days=1))
+    ).all()
+
+    # now we check the start time in the maintenance to verify
+
+    for maint in upcoming:
+
+        # skip maintenances that have already started
+        if maint.maintenance.started:
+            continue
+
+        start = datetime.combine(
+            maint.date,
+            maint.maintenance.start,
+            pytz.timezone(maint.maintenance.timezone),
+            )
+        start_utc = start.astimezone(pytz.utc)
+
+        if start_utc < (now + timedelta(minutes=minutes)):
+            starting_soon.append(maint)
+
+    # transform starting_soon
+    starting_soon = set(maint.maintenance for maint in starting_soon)
+
+    schema = MaintenanceSchema(many=True)
+
+    return schema.dump(starting_soon).data
+
+
+def ending_soon(minutes=5):
+    now = datetime.now(tz=pytz.utc)
+
+    ending_soon = []
+
+    # first we get a list of upcoming MaintCircuits, which have the date only
+
+    upcoming = MaintCircuit.query.filter(
+       MaintCircuit.date >= now.date(),
+       MaintCircuit.date <= (now.date() + timedelta(days=1))
+    ).all()
+
+    # now we check the end time in the maintenance to verify
+
+    for maint in upcoming:
+
+        # skip maintenances that have already ended
+        if maint.maintenance.ended:
+            continue
+
+        end = datetime.combine(
+            maint.date,
+            maint.maintenance.end,
+            pytz.timezone(maint.maintenance.timezone),
+            )
+        end_utc = end.astimezone(pytz.utc)
+
+        if end_utc < (now + timedelta(minutes=minutes)):
+            ending_soon.append(maint)
+
+    # transform ending_soon
+    ending_soon = set(maint.maintenance for maint in ending_soon)
+
+    schema = MaintenanceSchema(many=True)
+
+    return schema.dump(ending_soon).data

--- a/api/v1/swagger/main.yaml
+++ b/api/v1/swagger/main.yaml
@@ -317,6 +317,59 @@ paths:
                       date:
                         type: string
                         description: date of maintenance
+  /maintenances/in_progress:
+    get:
+      operationId: "api.v1.maintenances.in_progress"
+      tags:
+        - "Maintenances"
+      summary: "Get all maintenances in progress"
+      description: "GET all maintenances in progress"
+      responses:
+        200:
+          description: "Successful read maint list operation"
+          schema:
+            type: "array"
+            items:
+              properties:
+                id:
+                  type: "integer"
+                provider_maintenance_id:
+                  type: "string"
+                start:
+                  type: "string"
+                end:
+                  type: "string"
+                timezone:
+                  type: "string"
+                cancelled:
+                  type: "boolean"
+                rescheduled:
+                  type: "boolean"
+                rescheduled_id:
+                  type: "integer"
+                location:
+                  type: "string"
+                reason:
+                  type: "string"
+                received_dt:
+                  type: "string"
+                started:
+                  type: "boolean"
+                ended:
+                  type: "boolean"
+                circuits:
+                  type: array
+                  items:
+                    properties:
+                      circuit_id:
+                        type: integer
+                        description: Id of the circuit
+                      impact:
+                        type: string
+                        description: impact of the maintenace for this circuit
+                      date:
+                        type: string
+                        description: date of maintenance
   /maintenances/{maintenance_id}:
     get:
       operationId: 'api.v1.maintenances.read_one'
@@ -333,6 +386,126 @@ paths:
       responses:
         200:
           description: "Successful read maint list operation"
+          schema:
+            type: "array"
+            items:
+              properties:
+                id:
+                  type: "integer"
+                provider_maintenance_id:
+                  type: "string"
+                start:
+                  type: "string"
+                end:
+                  type: "string"
+                timezone:
+                  type: "string"
+                cancelled:
+                  type: "boolean"
+                rescheduled:
+                  type: "boolean"
+                rescheduled_id:
+                  type: "integer"
+                location:
+                  type: "string"
+                reason:
+                  type: "string"
+                received_dt:
+                  type: "string"
+                started:
+                  type: "boolean"
+                ended:
+                  type: "boolean"
+                circuits:
+                  type: array
+                  items:
+                    properties:
+                      circuit_id:
+                        type: integer
+                        description: Id of the circuit
+                      impact:
+                        type: string
+                        description: impact of the maintenace for this circuit
+                      date:
+                        type: string
+                        description: date of maintenance
+  /maintenances/starting_soon:
+    get:
+      operationId: "api.v1.maintenances.starting_soon"
+      tags:
+        - "Maintenances"
+      summary: "Get maintenances that are starting soon"
+      description: "GET all upcoming maintenances in the next X minutes"
+      parameters:
+        - name: minutes
+          in: query
+          description: number of minutes to look forward from now
+          type: integer
+          required: False
+          default: 5
+      responses:
+        200:
+          description: "Successful read maint list operation"
+          schema:
+            type: "array"
+            items:
+              properties:
+                id:
+                  type: "integer"
+                provider_maintenance_id:
+                  type: "string"
+                start:
+                  type: "string"
+                end:
+                  type: "string"
+                timezone:
+                  type: "string"
+                cancelled:
+                  type: "boolean"
+                rescheduled:
+                  type: "boolean"
+                rescheduled_id:
+                  type: "integer"
+                location:
+                  type: "string"
+                reason:
+                  type: "string"
+                received_dt:
+                  type: "string"
+                started:
+                  type: "boolean"
+                ended:
+                  type: "boolean"
+                circuits:
+                  type: array
+                  items:
+                    properties:
+                      circuit_id:
+                        type: integer
+                        description: Id of the circuit
+                      impact:
+                        type: string
+                        description: impact of the maintenace for this circuit
+                      date:
+                        type: string
+                        description: date of maintenance
+  /maintenances/ending_soon:
+    get:
+      operationId: "api.v1.maintenances.ending_soon"
+      tags:
+        - "Maintenances"
+      summary: "Get maintenances that are ending soon"
+      description: "GET all ending maintenances in the next X minutes"
+      parameters:
+        - name: minutes
+          in: query
+          description: number of minutes to look forward from now
+          type: integer
+          required: False
+          default: 5
+      responses:
+        200:
+          description: "Successful operation"
           schema:
             type: "array"
             items:

--- a/app/Providers.py
+++ b/app/Providers.py
@@ -401,7 +401,7 @@ class Zayo(Provider):
     def __init__(self):
         super().__init__()
         self.name = 'zayo'
-        self.type = 'backbone'
+        self.type = 'transit'
         self.email_esc = 'mr@zayo.com'
         if not Pro.query.filter_by(name=self.name, type=self.type).first():
             p = Pro(name=self.name, type=self.type, email_esc=self.email_esc)

--- a/app/Providers.py
+++ b/app/Providers.py
@@ -958,9 +958,9 @@ class GTT(Provider):
         return result
 
 
-class GTTalt(GTT):
+class Hibernia(GTT):
     '''
-    GTT
+    same provider, different email
     '''
 
     @property

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,13 @@ if HAS_SENTRY and SENTRY_DSN:
 def process_startup():
     process()
 
+def start_maint():
+    mark_started()
+
+def end_maint():
+    mark_ended()
+
+
 def create_app(config_class=Config):
     app = Flask(__name__)
     app.config.from_object(config_class)
@@ -52,6 +59,20 @@ def create_app(config_class=Config):
              'trigger': 'interval',
              'replace_existing': True,
              'seconds': int(app.config['CHECK_INTERVAL'])
+         },
+         {
+             'id': 'watch_started',
+             'func': start_maint,
+             'trigger': 'interval',
+             'replace_existing': True,
+             'seconds': int(280)
+         },
+         {
+             'id': 'watch_ended',
+             'func': end_maint,
+             'trigger': 'interval',
+             'replace_existing': True,
+             'seconds': int(280)
          }
     ]
     app.config['JOBS'] = JOBS
@@ -137,4 +158,4 @@ def connexion_register_blueprint(app, swagger_file, **kwargs):
 
 
 from app import models
-from app.jobs.main import process
+from app.jobs.main import process, mark_started, mark_ended

--- a/app/jobs/main.py
+++ b/app/jobs/main.py
@@ -8,7 +8,7 @@ from flask import current_app, jsonify
 from app import db, scheduler
 from app.models import Provider, Maintenance, MaintCircuit
 from app.MailClient import Gmail as mc
-from app.Providers import Zayo, NTT, PacketFabric, EUNetworks, GTT, GTTalt, Telia, Telstra, IN_PROGRESS
+from app.Providers import Zayo, NTT, PacketFabric, EUNetworks, GTT, Hibernia, Telia, Telstra, IN_PROGRESS
 
 from api.v1.maintenances import starting_soon, ending_soon
 from app.jobs.started import FUNCS as start_funcs
@@ -18,7 +18,7 @@ import email
 from datetime import datetime, timedelta
 import pytz
 
-PROVIDERS = [Zayo, NTT, PacketFabric, EUNetworks, GTT, GTTalt, Telia, Telstra]
+PROVIDERS = [Zayo, NTT, PacketFabric, EUNetworks, GTT, Hibernia, Telia, Telstra]
 
 
 def mark_started():

--- a/app/jobs/main.py
+++ b/app/jobs/main.py
@@ -42,9 +42,10 @@ def mark_started():
 
             scheduler.app.logger.info(f'{m.provider_maintenance_id} marked started via the api')
 
-            IN_PROGRESS.labels(provider=m.provider.name).inc()
+            IN_PROGRESS.labels(provider=mc.circuit.provider.name).inc()
 
             for func in start_funcs:
+                scheduler.app.logger.info(f'calling {func} for {m.provider_maintenance_id} due to job')
                 func(email=None, maintenance=m)
 
 
@@ -90,9 +91,10 @@ def mark_ended():
 
             scheduler.app.logger.info(f'{m.provider_maintenance_id} marked ended via the api')
 
-            IN_PROGRESS.labels(provider=m.provider.name).dec()
+            IN_PROGRESS.labels(provider=mc.circuit.provider.name).dec()
 
             for func in end_funcs:
+                scheduler.app.logger.info(f'calling function {func.__name__} for {m.provider_maintenance_id} due to job')
                 func(email=None, maintenance=m)
 
 def get_client():

--- a/app/jobs/main.py
+++ b/app/jobs/main.py
@@ -64,6 +64,9 @@ def mark_ended():
         for maint in upcoming_maints:
             m = Maintenance.query.get(maint['id'])
 
+            if not m.started:
+                continue
+
             mc = MaintCircuit.query.get(maint['circuits'][0]['id'])
 
             # we need to loop through each maintcircuit to verify


### PR DESCRIPTION
Version 0.3.0 of janitor adds 3 new api endpoints:

/in_progress: get a list of maintenances that have started but have not yet ended

/starting_soon?minutes=5: look ahead x minutes to return a list of maintenances that are starting in that time period

/ending_soon?minutes=5: look ahead x minutes to return a list of maintenances that are ending in that time period

This also adds two new jobs to APScheduler to mark maintenances started/ended using the new endpoints.